### PR TITLE
Updating for substrate 1.0 beta.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ serde_derive = { version = "1.0", optional = true }
 safe-mix = { version = "1.0", default-features = false}
 parity-codec = { version = "2.1", default-features = false }
 parity-codec-derive = { version = "2.1", default-features = false }
-substrate-keyring = { git = "https://github.com/paritytech/substrate/", optional = true }
-substrate-primitives = { git = "https://github.com/paritytech/substrate/", default-features = false }
-sr-std = { git = "https://github.com/paritytech/substrate/", default-features = false }
-sr-io = { git = "https://github.com/paritytech/substrate/", default-features = false }
-sr-primitives = { git = "https://github.com/paritytech/substrate/", default-features = false }
-srml-support = { git = "https://github.com/paritytech/substrate/", default-features = false }
-srml-system = { git = "https://github.com/paritytech/substrate/", default-features = false }
-srml-balances = { git = "https://github.com/paritytech/substrate/", default-features = false }
-srml-consensus = { git = "https://github.com/paritytech/substrate/", default-features = false }
-srml-session = { git = "https://github.com/paritytech/substrate/", default-features = false }
-srml-timestamp = { git = "https://github.com/paritytech/substrate/", default-features = false }
-srml-democracy = { git = "https://github.com/paritytech/substrate/", default-features = false }
+substrate-keyring = { git = "https://github.com/paritytech/substrate", branch = "v0.9", optional = true }
+substrate-primitives = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+sr-std = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+sr-io = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+sr-primitives = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+srml-support = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+srml-system = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+srml-balances = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+srml-consensus = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+srml-session = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+srml-timestamp = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
+srml-democracy = { git = "https://github.com/paritytech/substrate", branch = "v0.9", default-features = false }
 
 [features]
 default = ["std"]

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -118,7 +118,7 @@ decl_module! {
 
                     // Check if we approve the proposal, if so, mark approved
                     let total_issuance = <balances::Module<T>>::total_issuance();
-                    if VoteThreshold::SuperMajorityApprove.approved(stake_sum, total_issuance - stake_sum, total_issuance) {
+                    if VoteThreshold::SuperMajorityApprove.approved(stake_sum, total_issuance - stake_sum, total_issuance, total_issuance) {
                         <balances::Module<T>>::increase_free_balance_creating(&tgt, qty);
                         <DepositOf<T>>::insert(transaction_hash, (inx, tgt.clone(), qty, new_signers.clone(), true));
                         // TODO: fire event
@@ -200,7 +200,7 @@ decl_module! {
 
                     // Check if we approve the proposal
                     let total_issuance = <balances::Module<T>>::total_issuance();
-                    if VoteThreshold::SuperMajorityApprove.approved(stake_sum, total_issuance - stake_sum, total_issuance) {
+                    if VoteThreshold::SuperMajorityApprove.approved(stake_sum, total_issuance - stake_sum, total_issuance, total_issuance) {
                         match <balances::Module<T>>::decrease_free_balance(&tgt, qty) {
                             Ok(_) => {
                                 // TODO: do we still mark completed on error? or store a "failed" tx?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,12 @@ mod tests {
         const NOTE_OFFLINE_POSITION: u32 = 1;
         type Log = DigestItem;
         type SessionKey = u64;
-        type OnOfflineValidator = ();
+        type InherentOfflineReport = ();
     }
     impl timestamp::Trait for Test {
         const TIMESTAMP_SET_POSITION: u32 = 0;
         type Moment = u64;
+        type OnTimestampSet = ();
     }
     impl session::Trait for Test {
         type ConvertAccountIdToSessionKey = Identity;
@@ -146,11 +147,9 @@ mod tests {
             transfer_fee: 0,
             creation_fee: 0,
             reclaim_rebate: 0,
-            _genesis_phantom_data: Default::default(),
         }.build_storage().unwrap().0);
         t.extend(bridge::GenesisConfig::<Test>{
             authorities: vec![1, 2, 3],
-            _genesis_phantom_data: Default::default(),
         }.build_storage().unwrap().0);
         t.into()
     }


### PR DESCRIPTION
Pegging to substrate 1.0 beta aka branch "v0.9".

Most significant update is that the SRML Democracy module added an "electorate" size as well as a voter field. For now I left the logic the same by making electorate = voter, but given the increased flexibility of electorate size, we might want to revisit different supermajority algorithms as described in https://github.com/hicommonwealth/edge_bridge/issues/3